### PR TITLE
Update to Ubuntu 24.04 and Vala 0.56.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:noble
+
+ENV VALA_VERSION 0.45.91
+
+RUN apt-get update && apt-get install -y curl xz-utils gcc file flex bison libglib2.0-dev libgraphviz-dev
+
+RUN export VALA_MINOR_VERSION=$(echo $VALA_VERSION | sed -E 's/^([0-9]+)\.([0-9]+)\.([0-9]+)$/\1.\2/') && \
+    curl -fsSLO "https://download.gnome.org/sources/vala/$VALA_MINOR_VERSION/vala-$VALA_VERSION.tar.xz"
+
+RUN unxz "vala-$VALA_VERSION.tar.xz" \
+    && tar xvf "vala-$VALA_VERSION.tar" \
+    && cd "vala-$VALA_VERSION/" \
+    && ./configure --prefix=/usr \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && cd .. \
+    && rm -r "vala-$VALA_VERSION" "vala-$VALA_VERSION.tar"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:noble
 
-ENV VALA_VERSION 0.45.91
+ENV VALA_VERSION 0.56.18
 
-RUN apt-get update && apt-get install -y curl xz-utils gcc file flex bison libglib2.0-dev libgraphviz-dev
+RUN apt-get update && apt-get install -y curl xz-utils gcc file flex bison libglib2.0-dev libgraphviz-dev \
+    gobject-introspection
 
 RUN export VALA_MINOR_VERSION=$(echo $VALA_VERSION | sed -E 's/^([0-9]+)\.([0-9]+)\.([0-9]+)$/\1.\2/') && \
     curl -fsSLO "https://download.gnome.org/sources/vala/$VALA_MINOR_VERSION/vala-$VALA_VERSION.tar.xz"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Target distros:
 - Ubuntu
     - bionic (18.04)
     - disco (19.04)
-- Elementary
+    - noble (24.04)
+- elementary
     - Juno
+    - Circe
 - Fedora
     - latest (30)
     - rawhide (32)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 The eventual goal of this repo is to provide high quality, up-to-date, docker images with multiple compiler versions and distros:
 
 Target vala versions:
-- Current stable (0.46.0)
-- LTS (0.40.16)
+- Current stable LTS (0.56.18)
 
 Target distros:
 - Ubuntu
@@ -19,8 +18,8 @@ Target distros:
     - Juno
     - Circe
 - Fedora
-    - latest (30)
-    - rawhide (32)
+    - latest (42)
+    - rawhide (43)
 - Alpine
     - latest
 


### PR DESCRIPTION
Fixes #1

I didn't removed the old `Dockerfile.bionic` because I suspected it could be used to build image on [Docker Hub](https://hub.docker.com/u/valalang).

Confirmed this builds our image successfully on local:

```
user@elementary-daily:~/work/docker-images$ docker build . -t vala-lang:vala-lint
[+] Building 95.0s (8/8) FINISHED                                                                                docker:default
 => [internal] load build definition from Dockerfile                                                                       0.0s
 => => transferring dockerfile: 723B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/ubuntu:noble                                                            1.7s
 => [internal] load .dockerignore                                                                                          0.0s
 => => transferring context: 2B                                                                                            0.0s
 => CACHED [1/4] FROM docker.io/library/ubuntu:noble@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf2  0.0s
 => [2/4] RUN apt-get update && apt-get install -y curl xz-utils gcc file flex bison libglib2.0-dev libgraphviz-dev       54.8s
 => [3/4] RUN export VALA_MINOR_VERSION=$(echo 0.56.18 | sed -E 's/^([0-9]+)\.([0-9]+)\.([0-9]+)$/\1.\2/') &&     curl -f  0.3s 
 => [4/4] RUN unxz "vala-0.56.18.tar.xz"     && tar xvf "vala-0.56.18.tar"     && cd "vala-0.56.18/"     && ./configure   36.4s 
 => exporting to image                                                                                                     1.7s 
 => => exporting layers                                                                                                    1.6s 
 => => writing image sha256:a33eaddd542619fce82d6dd3f72de81f15407c34e7ad207b05514010c97ae029                               0.0s 
 => => naming to docker.io/library/vala-lang:vala-lint                                                                     0.0s 
                                                                                                                                
 1 warning found (use docker --debug to expand):                                                                                
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
user@elementary-daily:~/work/docker-images$ docker image ls
REPOSITORY   TAG         IMAGE ID       CREATED          SIZE
vala-lang    vala-lint   a33eaddd5426   44 seconds ago   696MB
user@elementary-daily:~/work/docker-images$ docker run -it vala-lang:vala-lint 
root@95892d08ae85:/# valac --version
Vala 0.56.18
root@95892d08ae85:/#
```